### PR TITLE
noproxy for direct communication to apiserver and timeouts of 3 seconds

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -534,7 +534,7 @@ get_networking_info() {
     CA_CRT=$(grep certificate-authority: "${COLLECT_DIR}"/kubelet/kubeconfig.yaml | sed 's/.*certificate-authority: //')
     for i in $(seq 5); do
       echo -e "curling ${API_SERVER} ($i of 5) $(date --utc +%FT%T.%3N%Z)\n\n" >> ${COLLECT_DIR}"/networking/curl_api_server.txt"
-      timeout 75 curl -v --connect-timeout 3 --no-proxy '*' --cacert "${CA_CRT}" "${API_SERVER}"/livez?verbose >> ${COLLECT_DIR}"/networking/curl_api_server.txt" 2>&1
+      timeout 75 curl -v --connect-timeout 3 --noproxy '*' --cacert "${CA_CRT}" "${API_SERVER}"/livez?verbose >> ${COLLECT_DIR}"/networking/curl_api_server.txt" 2>&1
     done
   fi
 

--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -534,7 +534,7 @@ get_networking_info() {
     CA_CRT=$(grep certificate-authority: "${COLLECT_DIR}"/kubelet/kubeconfig.yaml | sed 's/.*certificate-authority: //')
     for i in $(seq 5); do
       echo -e "curling ${API_SERVER} ($i of 5) $(date --utc +%FT%T.%3N%Z)\n\n" >> ${COLLECT_DIR}"/networking/curl_api_server.txt"
-      timeout 75 curl -v --cacert "${CA_CRT}" "${API_SERVER}"/livez?verbose >> ${COLLECT_DIR}"/networking/curl_api_server.txt" 2>&1
+      timeout 75 curl -v --connect-timeout 3 --no-proxy '*' --cacert "${CA_CRT}" "${API_SERVER}"/livez?verbose >> ${COLLECT_DIR}"/networking/curl_api_server.txt" 2>&1
     done
   fi
 

--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -534,7 +534,7 @@ get_networking_info() {
     CA_CRT=$(grep certificate-authority: "${COLLECT_DIR}"/kubelet/kubeconfig.yaml | sed 's/.*certificate-authority: //')
     for i in $(seq 5); do
       echo -e "curling ${API_SERVER} ($i of 5) $(date --utc +%FT%T.%3N%Z)\n\n" >> ${COLLECT_DIR}"/networking/curl_api_server.txt"
-      timeout 75 curl -v --connect-timeout 3 --noproxy '*' --cacert "${CA_CRT}" "${API_SERVER}"/livez?verbose >> ${COLLECT_DIR}"/networking/curl_api_server.txt" 2>&1
+      timeout 75 curl -v --connect-timeout 3 --max-time 10 --noproxy '*' --cacert "${CA_CRT}" "${API_SERVER}"/livez?verbose >> ${COLLECT_DIR}"/networking/curl_api_server.txt" 2>&1
     done
   fi
 


### PR DESCRIPTION
* connect-timeout 3 to reduce total execution time
* `noproxy '*'` if /etc/profile is set with a proxy, it should be direct.

**Issue #, if available:**

**Description of changes:**


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
